### PR TITLE
i9300: libsensors: fix possible overflow while setting delay

### DIFF
--- a/libsensors/input.c
+++ b/libsensors/input.c
@@ -214,10 +214,10 @@ int sysfs_path_prefix(char *name, char *path_prefix)
 	return -1;
 }
 
-int sysfs_value_read(char *path)
+int64_t sysfs_value_read(char *path)
 {
 	char buffer[100];
-	int value;
+	int64_t value;
 	int fd = -1;
 	int rc;
 
@@ -232,7 +232,7 @@ int sysfs_value_read(char *path)
 	if (rc <= 0)
 		goto error;
 
-	value = atoi(buffer);
+	value = (int64_t)strtoimax(buffer, NULL, 10);
 	goto complete;
 
 error:
@@ -245,7 +245,7 @@ complete:
 	return value;
 }
 
-int sysfs_value_write(char *path, int value)
+int sysfs_value_write(char *path, int64_t value)
 {
 	char buffer[100];
 	int fd = -1;
@@ -258,7 +258,7 @@ int sysfs_value_write(char *path, int value)
 	if (fd < 0)
 		goto error;
 
-	snprintf((char *) &buffer, sizeof(buffer), "%d\n", value);
+	snprintf((char *) &buffer, sizeof(buffer), "%" PRId64 "\n", value);
 
 	rc = write(fd, buffer, strlen(buffer));
 	if (rc < (int) strlen(buffer))

--- a/libsensors/smdk4x12_sensors.h
+++ b/libsensors/smdk4x12_sensors.h
@@ -83,8 +83,8 @@ int uinput_rel_create(const char *name);
 void uinput_destroy(int uinput_fd);
 int input_open(char *name);
 int sysfs_path_prefix(char *name, char *path_prefix);
-int sysfs_value_read(char *path);
-int sysfs_value_write(char *path, int value);
+int64_t sysfs_value_read(char *path);
+int sysfs_value_write(char *path, int64_t value);
 int sysfs_string_read(char *path, char *buffer, size_t length);
 int sysfs_string_write(char *path, char *buffer, size_t length);
 


### PR DESCRIPTION
Even though we changed the signature of the set_delay() methods,
we can still get an overflow while actually writing the values to sysfs.
Let's adapt sysfs_value_read() and sysfs_value_write() too.

Change-Id: If8eda7204831f0edabec890d4e3127be520fa3bf
